### PR TITLE
* Handling font file corruption issues.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,31 +113,15 @@ jar {
     exclude '**/*.properties'
 
     doLast {
-        def f = new File('dist/lib/NotoSansCJKtc-Regular.ttf')
-        if (f.exists() && f.size() > 100) {
-            println "Font file already exists, distributing.."
-            copy {
-                from file('dist/lib/NotoSansCJKtc-Regular.ttf')
-                into 'resources/'
-            }
+        copy {
+            from file('dist/lib/NotoSansCJKtc-Regular.ttf')
+            into 'resources/'
         }
      	copy {
             from file('resources/')
             into 'dist/conf'
         }
         if (!gradle.startParameter.isOffline()) {
-            if (!f.exists() || (f.exists() && f.size() < 100)) {
-                println "Font file does not exist, starting to download and distribute.."
-                new URL('https://github.com/WeBankFinTech/WeIdentity/blob/master/dist/lib/NotoSansCJKtc-Regular.ttf').withInputStream { i ->
-                    f.withOutputStream {
-                        it << i
-                    }
-                }
-                copy {
-                    from file('dist/lib/NotoSansCJKtc-Regular.ttf')
-                    into 'resources/'
-                }
-            }
             copy {
                 from configurations.runtime
                 from configurations.localDeps

--- a/compile.sh
+++ b/compile.sh
@@ -15,11 +15,6 @@ fi
 if [ ! -d dist/lib ];then
     mkdir dist/lib
 fi
-if [ ! -d dist/lib/NotoSansCJKtc-Regulat.ttf ];then
-    cd dist/lib
-    touch NotoSansCJKtc-Regular.ttf
-    cd ../..
-fi
 
 #SOURCE_CODE_DIR=$(pwd)
 CONFIG_FILE=${SOURCE_CODE_DIR}/conf/run.config
@@ -155,8 +150,19 @@ function check_parameter()
     fi
 }
 
+function check_font()
+{
+  md5file=`cat dist/lib/NotoSansCJKtc-Regular.md5`
+  md5font=`md5sum dist/lib/NotoSansCJKtc-Regular.ttf | cut -d ' ' -f1`
+  if [ "$md5file" != "$md5font" ];then
+    echo "font file is broken."
+    exit 1
+  fi
+}
+
 function main()
 {
+    check_font
     check_parameter
     setup
     check_jdk

--- a/dist/lib/NotoSansCJKtc-Regular.md5
+++ b/dist/lib/NotoSansCJKtc-Regular.md5
@@ -1,0 +1,1 @@
+b4bbe420d4800d1b7a9d04bce793b79d


### PR DESCRIPTION
1. 新增字体文件，放在dist/lib目录下。
2. 新增存放字体哈希值的文件，放在dist/lib目录下。
3. 在compile.sh脚本中计算字体文件大小，再与存放的哈希值对比，如果字体文件损坏，提示：font
file is broken错误。