### PR TITLE
【*】任务18.  更新Weld-Build-Tools的deploy.sh脚本，实现运行该脚本完成Weldentity的配置和部署即跟网页可视化配置效果一致

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -106,7 +106,7 @@ function clean_data()
 
 function check_node_cert(){
 
-    cd ${SOURCE_CODE_DIR}/resources
+    cd ${SOURCE_CODE_DIR}/resources/conf
     if [ "${blockchain_fiscobcos_version}" = "1" ];then
         if [ ! -f  ca.crt -o ! -f  client.keystore ];then
             echo "ERROR : fisco bcos version is 1.3, ca.crt and client.keystore are needed."
@@ -121,6 +121,18 @@ function check_node_cert(){
         else
             if [ ! -f  gmca.crt -o ! -f  gmsdk.crt -o ! -f  gmsdk.key -o ! -f  gmensdk.crt -o ! -f  gmensdk.key ];then
                 echo "ERROR : fisco bcos version is 2.0, encrypt type is SM2, gmca.crt, gmsdk.crt, gmsdk.key, gmensdk.crt and gmensdk.key are needed."
+                exit 1
+            fi
+        fi
+    elif [ "${blockchain_fiscobcos_version}" = "3" ];then
+        if [ "${encrypt_type}" = "0" ];then
+            if [ ! -f  ca.crt -o ! -f  sdk.crt -o ! -f  sdk.key ];then
+                echo "ERROR : fisco bcos version is 3.0. encrypt type is ECDSA, ca.crt, sdk.crt and sdk.key are needed."
+                exit 1
+            fi
+        else
+            if [ ! -f  sm_ca.crt -o ! -f  sm_sdk.crt -o ! -f  sm_sdk.key -o ! -f  sm_ensdk.crt -o ! -f  sm_ensdk.key ];then
+                echo "ERROR : fisco bcos version is 3.0, encrypt type is SM2, sm_ca.crt, sm_sdk.crt, sm_sdk.key, sm_ensdk.crt and sm_ensdk.key are needed."
                 exit 1
             fi
         fi

--- a/src/main/java/com/webank/weid/command/CommandArgs.java
+++ b/src/main/java/com/webank/weid/command/CommandArgs.java
@@ -1,5 +1,4 @@
 
-
 package com.webank.weid.command;
 
 import java.util.ArrayList;
@@ -73,4 +72,7 @@ public class CommandArgs {
     
     @Parameter(names = "--desc", description = "desc")
     private String desc;
+
+    @Parameter(names = "--apply-name", description = "apply name")
+    private String applyName;
 }

--- a/src/main/java/com/webank/weid/command/DeployContract.java
+++ b/src/main/java/com/webank/weid/command/DeployContract.java
@@ -1,5 +1,4 @@
 
-
 package com.webank.weid.command;
 
 import com.beust.jcommander.JCommander;
@@ -9,6 +8,7 @@ import com.webank.weid.blockchain.constant.CnsType;
 import com.webank.weid.blockchain.deploy.v2.DeployContractV2;
 import com.webank.weid.blockchain.deploy.v3.DeployContractV3;
 import com.webank.weid.config.StaticConfig;
+import com.webank.weid.constant.BuildToolsConstant;
 import com.webank.weid.constant.DataFrom;
 import com.webank.weid.dto.DeployInfo;
 import com.webank.weid.protocol.base.WeIdPrivateKey;
@@ -44,6 +44,7 @@ public class DeployContract extends StaticConfig {
             .parse(args);
         String chainId = commandArgs.getChainId();
         String privateKeyFile = commandArgs.getPrivateKey();
+        String applyName = commandArgs.getApplyName();
         // 获取配置
         FiscoConfig fiscoConfig = WeIdSdkUtils.loadNewFiscoConfig();
         fiscoConfig.setChainId(chainId);
@@ -54,9 +55,17 @@ public class DeployContract extends StaticConfig {
         }
         // 部署合约
         String hash = contractService.deployContract(fiscoConfig, DataFrom.COMMAND);
-        System.out.println("the contract deploy successfully  --> hash : " +  hash);
+        System.out.println("the contract deploy successfully  --> hash : " + hash);
+        // 将应用名写入配置中
+        if (StringUtils.isNotBlank(applyName)) {
+            com.webank.weid.blockchain.protocol.response.ResponseData<Boolean> response = WeIdSdkUtils
+                    .getDataBucket(CnsType.DEFAULT)
+                    .put(hash, BuildToolsConstant.APPLY_NAME, applyName,
+                            WeIdSdkUtils.getWeIdPrivateKey(hash).getPrivateKey());
+            System.out.println("[deploy] put applyName: " + applyName + ", resp: " + response);
+        }
         // 配置启用新hash
-        String  oldHash = WeIdSdkUtils.getMainHash();
+        String oldHash = WeIdSdkUtils.getMainHash();
         // 获取部署数据
         DeployInfo deployInfo = contractService.getDeployInfoByHashFromChain(hash);
         ContractConfig contract = new ContractConfig();


### PR DESCRIPTION
任务18.  更新Weld-Build-Tools的deploy.sh脚本，实现运行该脚本完成Weldentity的配置和部署即跟网页可视化配置效果一致
1. 修复deploy.sh对于证书文件文件检查路径，并增加bcos3.0支持；
2. 增加deploy.sh应用名称设置： ./deploy.sh --apply-name xxx